### PR TITLE
fix node 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "4"
   - "6"
-  - "7"
+  - "8"
+  - "9"

--- a/rules/sort-imports-es6.js
+++ b/rules/sort-imports-es6.js
@@ -135,7 +135,7 @@ module.exports = {
                               ? ''
                               : initial.slice(importSpecifiers[index].range[1], importSpecifiers[index + 1].range[0]);
 
-                          return sourceText + initial.substring(...specifier.range) + textAfterSpecifier;
+                          return sourceText + initial.substring.apply(initial, specifier.range) + textAfterSpecifier;
                       }, '');
 
                   return [node, `${before}${between}${after}`];


### PR DESCRIPTION
no issue
- es6 spread operator isn't available in Node v4 which is still in LTS maintenance
- tests now pass under node v4