### PR TITLE
fix: add support for svelte file handling

### DIFF
--- a/rules/sort-imports-es6.js
+++ b/rules/sort-imports-es6.js
@@ -60,6 +60,12 @@ module.exports = {
             initialSource = null,
             allDeclarations = sourceCode.ast.body.filter(n => n.type === 'ImportDeclaration');
 
+        const svelteScriptElement = sourceCode.ast.body.filter(n => n.type === 'SvelteScriptElement');
+
+        if (svelteScriptElement[0]) {
+            allDeclarations = svelteScriptElement[0].body.filter(n => n.type === 'ImportDeclaration');
+        }
+
         /**
          * Gets the used member syntax style.
          *


### PR DESCRIPTION
This commit adds a simple check to see if the file being parsed is a Svelte file. If so, it assigns `allDeclarations` to the imports within the Svelte script tag so that they can be ordered correctly.